### PR TITLE
Redirect memote.io -> memote.dd-decaf.eu

### DIFF
--- a/deployment/ingress.yml
+++ b/deployment/ingress.yml
@@ -15,3 +15,25 @@ spec:
         backend:
           serviceName: memote-service-frontend-staging
           servicePort: 80
+
+---
+
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: memote-service-frontend-redirect
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: https://memote.io
+spec:
+  tls:
+  - hosts:
+    - memote.dd-decaf.eu
+    secretName: decaf-tls
+  rules:
+  - host: memote.dd-decaf.eu
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: memote-service-frontend-staging
+          servicePort: 80

--- a/deployment/ingress.yml
+++ b/deployment/ingress.yml
@@ -5,10 +5,10 @@ metadata:
 spec:
   tls:
   - hosts:
-    - memote.dd-decaf.eu
-    secretName: decaf-tls
+    - memote.io
+    secretName: memote-tls
   rules:
-  - host: memote.dd-decaf.eu
+  - host: memote.io
     http:
       paths:
       - path: /


### PR DESCRIPTION
Ensures that https certificate is valid for requests to memote.dd-decaf.eu before redirecting