### PR TITLE
Don't poll expired tasks

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -30,7 +30,7 @@ export default {
     // Loop all tasks and refresh their status indefinitely.
     const pollTasksLoop = () => {
       this.$store.state.tasks
-        .filter(task => !['SUCCESS', 'FAILURE'].includes(task.status))
+        .filter(task => !['SUCCESS', 'FAILURE', 'EXPIRED'].includes(task.status))
         .forEach((task, index) => {
           this.$store.dispatch('pollTaskStatus', { task, index });
         });

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,9 +29,11 @@ export default {
 
     // Loop all tasks and refresh their status indefinitely.
     const pollTasksLoop = () => {
-      this.$store.state.tasks.forEach((task, index) => {
-        this.$store.dispatch('pollTaskStatus', { task, index });
-      });
+      this.$store.state.tasks
+        .filter(task => !['SUCCESS', 'FAILURE'].includes(task.status))
+        .forEach((task, index) => {
+          this.$store.dispatch('pollTaskStatus', { task, index });
+        });
       setTimeout(pollTasksLoop, 3000);
     };
     pollTasksLoop();

--- a/src/store.js
+++ b/src/store.js
@@ -51,10 +51,6 @@ export default new Vuex.Store({
       context.dispatch('storeTasks');
     },
     pollTaskStatus(context, payload) {
-      if (payload.task.status === 'SUCCESS' || payload.task.status === 'FAILURE') {
-        return;
-      }
-
       axios
         .get(`${settings.api}/status/${payload.task.uuid}`)
         .then((response) => {

--- a/src/store.js
+++ b/src/store.js
@@ -56,7 +56,7 @@ export default new Vuex.Store({
         .then((response) => {
           if (response.data.status === 'PENDING') {
             // PENDING in celery means "don't know". If the job is not expired, assume it is in the queue, otherwise
-            // mark it as expired.
+            // mark it as expired and forget about it.
             if (moment(payload.task.expiry).isBefore(moment())) {
               payload.task.status = 'EXPIRED';
             } else {


### PR DESCRIPTION
Minor fix. Tasks with success or failure state are not polled further to check for update - with this fix, that is also the case for expired tasks.